### PR TITLE
Fix flaky test for TSFresh entropy

### DIFF
--- a/tests/test_tsfresh.py
+++ b/tests/test_tsfresh.py
@@ -65,6 +65,8 @@ from functime.feature_extractors import (
     variation_coefficient,
 )
 
+ERROR_EPSION = 1e-10
+
 np.random.seed(42)
 
 
@@ -471,7 +473,7 @@ def test_approximate_entropy(S, res, m, r, scale):
             )
             - res
         )
-        < 1e-10
+        < ERROR_EPSION
     )
 
 

--- a/tests/test_tsfresh.py
+++ b/tests/test_tsfresh.py
@@ -465,10 +465,13 @@ def test_absolute_sum_of_changes(S, res):
 )
 def test_approximate_entropy(S, res, m, r, scale):
     assert (
-        approximate_entropy(
-            x=pl.Series(S), run_length=m, filtering_level=r, scale_by_std=scale
+        abs(
+            approximate_entropy(
+                x=pl.Series(S), run_length=m, filtering_level=r, scale_by_std=scale
+            )
+            - res
         )
-        == res
+        < 1e-10
     )
 
 
@@ -1117,6 +1120,7 @@ def test_mean_n_absolute_max(S, n_max, res):
 #         mean_n_absolute_max(x=pl.Series([12, 3]), n_maxima=0)
 #     with pytest.raises(ValueError):
 #         mean_n_absolute_max(x=pl.Series([12, 3]), n_maxima=-1)
+
 
 @pytest.mark.parametrize(
     "S, res",


### PR DESCRIPTION
## Reference Issues/PRs

Related to #70, fixes float flakiness of `test_approximate_entropy`

## What does this implement/fix? Explain your changes.

Switch to check within an epsion rather than exact value.

Didn't notice any other tests like this - searched for `==` within tests, they check ints. :)